### PR TITLE
Sync supported audio track types to Chromium capability

### DIFF
--- a/modules/is-supported.js
+++ b/modules/is-supported.js
@@ -1,19 +1,20 @@
+/**
+ * Ref: https://www.chromium.org/audio-video
+ */
 module.exports = function isSupported(file) {
   const parts = file.split('.');
   const format = parts[parts.length - 1].toLowerCase();
   switch (format) {
     case 'wav':
-      return true;
     case 'mp3':
-      return true;
     case 'mp4':
-      return true;
-    case 'adts':
-      return true;
+    case 'm4a':
+    case 'oga':
+    case 'ogm':
     case 'ogg':
-      return true;
-    case 'webm':
-      return true;
+    case 'spx':
+    case 'opus':
+    case 'webm':  // not supported by music-metadata yet
     case 'flac':
       return true;
     default:

--- a/src/js/View.js
+++ b/src/js/View.js
@@ -179,7 +179,7 @@ module.exports = class View {
               album.innerText = meta.album ? meta.album : 'Unknown';
               artist.innerText = meta.artist ? meta.artist : 'Unknown';
             },
-            onError: err => console.error(err)
+            onError: err => console.error(err.message)
           });
       } else {
         name.innerText = files[i].name;


### PR DESCRIPTION
Updated supported audio types with [supported file extensions in Chomium](https://sites.google.com/a/chromium.org/dev/audio-video).

- Removed: adts
- Added: oga, agm, spx, opus, m4a
